### PR TITLE
Prevent interfering w/styles on wrapped components

### DIFF
--- a/src/index.svelte
+++ b/src/index.svelte
@@ -32,3 +32,9 @@
 <div bind:this={child}>
   <slot></slot>
 </div>
+
+<style>
+  div {
+    display: contents
+  }
+</style>


### PR DESCRIPTION
Adding a wrapper div around existing elements can cause their position to shift. This small change fixes that.